### PR TITLE
Create and publish image when make a release on github

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,9 +1,7 @@
 name: Docker Image CI
 on:
-  push:
-    branches: 
-      - main
-    tags: '*'
+  release:
+    types: [published]
 
 jobs:
   build_and_publish:
@@ -19,9 +17,8 @@ jobs:
         with:
           images: |
             genomenexus/vcf2maf-lite
-          # The latest tag will also be generated on tag event with a valid semver tag
+          # latest tag is also generated for valid semver release tags
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
 
       # The following two actions are required to build multi-platform images


### PR DESCRIPTION
- Create and publish image when make a release on github
- `latest` tag is automatically added for valid semver tags
-  No image is published on regular pushes to main anymore. The PyPI workflow is unchanged